### PR TITLE
retro-compatibility with generator packages

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -41,7 +41,12 @@ def write_generators(conanfile, path, output):
                         (generator_name, ", ".join(registered_generators.available)))
         else:
             generator_class = registered_generators[generator_name]
-            generator = generator_class(conanfile)
+            try:
+                generator = generator_class(conanfile)
+            except TypeError:
+                # To allow old-style generator packages to work (e.g. premake)
+                output.warn("Generator %s failed with new __init__(), trying old one")
+                generator = generator_class(conanfile.deps_cpp_info, conanfile.cpp_info)
             output.info("Generated %s created %s" % (generator_name, generator.filename))
             content = normalize(generator.content)
             save(join(path, generator.filename), content)

--- a/conans/client/generators/visualstudio.py
+++ b/conans/client/generators/visualstudio.py
@@ -28,17 +28,18 @@ class VisualStudioGenerator(Generator):
 
     def __init__(self, conanfile):
         super(VisualStudioGenerator, self).__init__(conanfile)
-        self.bin_dirs = "".join('%s;'  % p.replace("\\", "/")
-                                    for p in conanfile.deps_cpp_info.bin_paths)
+        deps_cpp_info = conanfile.deps_cpp_info
+        self.bin_dirs = "".join('%s;' % p.replace("\\", "/")
+                                for p in deps_cpp_info.bin_paths)
         self.include_dirs = "".join('%s;' % p.replace("\\", "/")
-                                    for p in conanfile.deps_cpp_info.include_paths)
+                                    for p in deps_cpp_info.include_paths)
         self.lib_dirs = "".join('%s;' % p.replace("\\", "/")
-                                for p in conanfile.deps_cpp_info.lib_paths)
+                                for p in deps_cpp_info.lib_paths)
         self.libs = "".join(['%s.lib;' % lib if not lib.endswith(".lib")
-                             else '%s;' % lib for lib in conanfile.deps_cpp_info.libs])
-        self.definitions = "".join("%s;" % d for d in conanfile.deps_cpp_info.defines)
-        self.compiler_flags = " ".join(conanfile.deps_cpp_info.cppflags + conanfile.deps_cpp_info.cflags)
-        self.linker_flags = " ".join(conanfile.deps_cpp_info.sharedlinkflags)
+                             else '%s;' % lib for lib in deps_cpp_info.libs])
+        self.definitions = "".join("%s;" % d for d in deps_cpp_info.defines)
+        self.compiler_flags = " ".join(deps_cpp_info.cppflags + deps_cpp_info.cflags)
+        self.linker_flags = " ".join(deps_cpp_info.sharedlinkflags)
 
     @property
     def filename(self):

--- a/conans/client/generators/xcode.py
+++ b/conans/client/generators/xcode.py
@@ -16,14 +16,15 @@ OTHER_CPLUSPLUSFLAGS = $(inherited)
 
     def __init__(self, conanfile):
         super(XCodeGenerator, self).__init__(conanfile)
+        deps_cpp_info = conanfile.deps_cpp_info
         self.include_dirs = " ".join('"%s"' % p.replace("\\", "/")
-                                     for p in conanfile.deps_cpp_info.include_paths)
+                                     for p in deps_cpp_info.include_paths)
         self.lib_dirs = " ".join('"%s"' % p.replace("\\", "/")
-                                 for p in conanfile.deps_cpp_info.lib_paths)
-        self.libs = " ".join(['-l%s' % lib for lib in conanfile.deps_cpp_info.libs])
-        self.definitions = " ".join('"%s"' % d for d in conanfile.deps_cpp_info.defines)
-        self.compiler_flags = " ".join(conanfile.deps_cpp_info.cppflags + conanfile.deps_cpp_info.cflags)
-        self.linker_flags = " ".join(conanfile.deps_cpp_info.sharedlinkflags)
+                                 for p in deps_cpp_info.lib_paths)
+        self.libs = " ".join(['-l%s' % lib for lib in deps_cpp_info.libs])
+        self.definitions = " ".join('"%s"' % d for d in deps_cpp_info.defines)
+        self.compiler_flags = " ".join(deps_cpp_info.cppflags + deps_cpp_info.cflags)
+        self.linker_flags = " ".join(deps_cpp_info.sharedlinkflags)
 
     @property
     def filename(self):

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -1,7 +1,6 @@
 import os
 import re
 from conans.errors import ConanException
-from conans.client.generators import TXTGenerator
 from conans.util.log import logger
 import traceback
 from collections import OrderedDict
@@ -82,12 +81,6 @@ class DepsCppInfo(_CppInfo):
 
     def __getitem__(self, item):
         return self._dependencies[item]
-
-    def __repr__(self):
-        dummy_conanfile = type('',(object,),{
-            'deps_cpp_info':self,
-            'cpp_info':None})()
-        return TXTGenerator(dummy_conanfile).content
 
     @staticmethod
     def loads(text):

--- a/conans/test/model/build_info_test.py
+++ b/conans/test/model/build_info_test.py
@@ -1,5 +1,7 @@
 import unittest
 from conans.model.build_info import DepsCppInfo
+from conans.client.generators import TXTGenerator
+from collections import namedtuple
 
 
 class BuildInfoTest(unittest.TestCase):
@@ -10,15 +12,16 @@ class BuildInfoTest(unittest.TestCase):
                              getattr(item2, field))
 
     def help_test(self):
-        imports = DepsCppInfo()
-        imports.includedirs.append("C:/whatever")
-        imports.includedirs.append("C:/whenever")
-        imports.libdirs.append("C:/other")
-        imports.libs.extend(["math", "winsock", "boost"])
+        deps_cpp_info = DepsCppInfo()
+        deps_cpp_info.includedirs.append("C:/whatever")
+        deps_cpp_info.includedirs.append("C:/whenever")
+        deps_cpp_info.libdirs.append("C:/other")
+        deps_cpp_info.libs.extend(["math", "winsock", "boost"])
         child = DepsCppInfo()
         child.includedirs.append("F:/ChildrenPath")
         child.cppflags.append("cxxmyflag")
-        imports._dependencies["Boost"] = child
-        output = repr(imports)
-        imports2 = DepsCppInfo.loads(output)
-        self._equal(imports, imports2)
+        deps_cpp_info._dependencies["Boost"] = child
+        fakeconan = namedtuple("Conanfile", "deps_cpp_info cpp_info")
+        output = TXTGenerator(fakeconan(deps_cpp_info, None)).content
+        deps_cpp_info2 = DepsCppInfo.loads(output)
+        self._equal(deps_cpp_info, deps_cpp_info2)


### PR DESCRIPTION
1 important thing and minor styling:

1 important:
- Keep retro-compatibility with existing generator packages, that are not in the codebase, but as packages. At least the premake one is there. They can be upgraded by they authors, but let them not to fail

Minor:
- Creating intermediate variables when x.y.z appears many times. Side effect: resulting PR diff is smaller, easier to check.
- Removed unnecessary repr(), it was used only for testing, removed the fix of temp conanfile and put it in test.

These are really minor, overall it is a great job, thanks very mucha!
